### PR TITLE
Avoid ConfiguredResult dequeuing while specifying Return value

### DIFF
--- a/Source/NSubstitute.Acceptance.Specs/CallBaseForMember.cs
+++ b/Source/NSubstitute.Acceptance.Specs/CallBaseForMember.cs
@@ -149,7 +149,6 @@ namespace NSubstitute.Acceptance.Specs
             }
 
             [Test]
-            [Ignore("Should/can we avoid call base here?")]
             public void
                 Given_SubstituteForClass_When_VirtualMethodsReturnValueIsOverwritten_Then_ShouldNotCallBaseImplementation
                 ()

--- a/Source/NSubstitute/Routing/RouteFactory.cs
+++ b/Source/NSubstitute/Routing/RouteFactory.cs
@@ -48,7 +48,6 @@ namespace NSubstitute.Routing
             return new Route(new ICallHandler[] {
                 new RecordCallSpecificationHandler(state.PendingSpecification, state.CallSpecificationFactory, state.CallActions)
                 , new PropertySetterHandler(new PropertyHelper(), state.ConfigureCall)
-                , new ReturnConfiguredResultHandler(state.CallResults)
                 , new ReturnAutoValueForThisAndSubsequentCallsHandler(state.AutoValueProviders, state.ConfigureCall)
                 , ReturnDefaultForReturnTypeHandler()
             });


### PR DESCRIPTION
Am I right that ReturnConfiguredResultHandler can be removed from RecordCallSpecificationHandler?
