### PR TITLE
Use VersionPrefix and VersionSuffix instead of Version. Only one target framework.

### DIFF
--- a/src/NSubstitute/NSubstitute.csproj
+++ b/src/NSubstitute/NSubstitute.csproj
@@ -1,14 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <Description>NSubstitute is a friendly substitute for .NET mocking frameworks. It has a simple, succinct syntax to help developers write clearer tests. NSubstitute is designed for Arrange-Act-Assert (AAA) testing and with Test Driven Development (TDD) in mind.</Description>
-    <Version>3.0.0</Version>
+    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionSuffix>beta1</VersionSuffix>
     <Authors>Anthony Egerton;David Tchepak;Alexandr Nikitin</Authors>
-    <TargetFrameworks>netstandard1.3;net452</TargetFrameworks>
+    <TargetFramework>netstandard1.3</TargetFramework>
     <AssemblyName>NSubstitute</AssemblyName>
     <PackageId>NSubstitute</PackageId>
     <PackageTags>mocking;mocks;testing;unit-testing;TDD;AAA</PackageTags>


### PR DESCRIPTION
I think it's safe to release this as a beta version using dotnet cli `C:\Projects\contrib\NSubstitute\src\NSubstitute>dotnet pack -c Release --include-symbols` and pushing the package to NuGet.