### PR TITLE
Move Microsoft.CSharp dependency to client side

### DIFF
--- a/src/NSubstitute/NSubstitute.csproj
+++ b/src/NSubstitute/NSubstitute.csproj
@@ -29,7 +29,6 @@
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.2.0-*" />
     <PackageReference Include="System.Linq.Queryable" Version="4.3.0-*" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
   </ItemGroup>
 

--- a/tests/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
+++ b/tests/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
@@ -18,6 +18,10 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\NSubstitute\NSubstitute.csproj" />
   </ItemGroup>


### PR DESCRIPTION
It's referenced in Full .NET projects by default.