### PR TITLE
Sort out csproj dependencies

### DIFF
--- a/src/NSubstitute/NSubstitute.csproj
+++ b/src/NSubstitute/NSubstitute.csproj
@@ -31,12 +31,17 @@
 
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.2.0-*" />
-    <PackageReference Include="System.Linq.Queryable" Version="4.3.0-*" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0-*" />
   </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)'!='net45'">
+  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <PackageReference Include="System.Linq.Queryable" Version="4.3.0-*" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0-*" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' OR '$(TargetFramework)'=='net46'">
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I think it's better to use `<Reference Include="..." />` than `<PackageReference Include="..."/>` for Full .NET Frameworks. So it won't add a bunch of NuGet packages.

BTW, the original version had those changes https://github.com/nsubstitute/NSubstitute/blob/f7fc2727ac2f35cbf2a69458fe710087a8c5a565/src/NSubstitute/NSubstitute.csproj

... including `<PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>` 